### PR TITLE
Fix falcon request usage according to falcon package changes

### DIFF
--- a/displacy_service/server.py
+++ b/displacy_service/server.py
@@ -115,7 +115,7 @@ class DepResource(object):
     """
 
     def on_post(self, req, resp):
-        req_body = req.stream.read()
+        req_body = req.bounded_stream.read()
         json_data = json.loads(req_body.decode('utf8'))
         text = json_data.get('text')
         model_name = json_data.get('model', 'en')
@@ -139,7 +139,7 @@ class EntResource(object):
     """Parse text and return displaCy ent's expected output."""
 
     def on_post(self, req, resp):
-        req_body = req.stream.read()
+        req_body = req.bounded_stream.read()
         json_data = json.loads(req_body.decode('utf8'))
         text = json_data.get('text')
         model_name = json_data.get('model', 'en')
@@ -159,7 +159,7 @@ class SentsResources(object):
     """Returns sentences"""
 
     def on_post(self, req, resp):
-        req_body = req.stream.read()
+        req_body = req.bounded_stream.read()
         json_data = json.loads(req_body.decode('utf8'))
         text = json_data.get('text')
         model_name = json_data.get('model', 'en')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy
-falcon
+spacy==2.0.16
+falcon==2.0.0
 pytest
-requests
+requests==2.21.0


### PR DESCRIPTION
Falcon changed their API for bounded stream and it upgraded automatic to falcon latest version.
Therefore, I did the follow: 
* Specified certain versions for the required python packages (currently latest versions for each package) to avoid bugs like that in the future and 
* Fixed the falcon request bounded stream usage

#23 