### PR TITLE
Update spacy version to latest and add large/medium images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
 install:
   - travis_wait 30 docker build -t jgontrum/spacyapi:base_v2 .
   - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2 -f docker/en/Dockerfile .
+  - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2_lg -f docker/en/Dockerfile.lg .
+  - travis_wait 30 docker build -t jgontrum/spacyapi:en_v2_md -f docker/en/Dockerfile.md .
   - travis_wait 30 docker build -t jgontrum/spacyapi:de_v2 -f docker/de/Dockerfile .
   - travis_wait 30 docker build -t jgontrum/spacyapi:es_v2 -f docker/es/Dockerfile .
   - travis_wait 30 docker build -t jgontrum/spacyapi:fr_v2 -f docker/fr/Dockerfile .
@@ -23,6 +25,8 @@ install:
 after_success:
   - docker push jgontrum/spacyapi:base_v2
   - docker push jgontrum/spacyapi:en_v2
+  - docker push jgontrum/spacyapi:en_v2_lg
+  - docker push jgontrum/spacyapi:en_v2_md
   - docker push jgontrum/spacyapi:de_v2
   - docker push jgontrum/spacyapi:es_v2
   - docker push jgontrum/spacyapi:fr_v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 
 # Install node for the frontend
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get install -y nodejs &&\
   apt-get -q clean -y && rm -rf /var/lib/apt/lists/* && rm -f /var/cache/apt/*.bin
 

--- a/docker/en/Dockerfile.lg
+++ b/docker/en/Dockerfile.lg
@@ -1,0 +1,4 @@
+FROM jgontrum/spacyapi:base_v2
+
+ENV languages "en_core_web_lg"
+RUN cd /app && env/bin/download_models

--- a/docker/en/Dockerfile.md
+++ b/docker/en/Dockerfile.md
@@ -1,0 +1,4 @@
+FROM jgontrum/spacyapi:base_v2
+
+ENV languages "en_core_web_md"
+RUN cd /app && env/bin/download_models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy
+spacy==2.2.*
 falcon==2.0.0
 pytest
 requests==2.21.0


### PR DESCRIPTION
Pin Spacy version to 2.2.* so when updates happen, pipelines can be kicked off. 
Also added dockerfiles for large and medium models for english